### PR TITLE
feat: add schema for built in tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,6 @@ export interface ToolSchema {
 
   LS: {
     input: {
-      ignore?: string[];
       path: string;
     };
     response: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,9 @@ export interface ToolSchema {
       command: string;
       description?: string;
       run_in_background?: boolean;
+      /**
+       * Timeout in milliseconds for the process (ignored if run_in_background is true).
+       */
       timeout?: number;
     };
     response: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import type { ClaudeCodeTodo } from "./hook-types";
+import type { AutoComplete } from "./utils/types";
 
 /**
  * Represents the input schema for each tool in the `PreToolUse` and `PostToolUse` hooks.
@@ -38,7 +39,9 @@ export interface ToolSchema {
   Bash: {
     input: {
       command: string;
-      description: string;
+      description?: string;
+      run_in_background?: boolean;
+      timeout?: number;
     };
     response: {
       interrupted: boolean;
@@ -48,9 +51,39 @@ export interface ToolSchema {
     };
   };
 
+  Edit: {
+    input: {
+      file_path: string;
+      new_string: string;
+      old_string: string;
+      /**
+       * @default false
+       */
+      replace_all?: boolean;
+    };
+    response: {
+      filePath: string;
+      newString: string;
+      oldString: string;
+      originalFile: string;
+      replaceAll: boolean;
+      structuredPatch: Array<{
+        lines: string[];
+        newLines: number;
+        newStart: number;
+        oldLines: number;
+        oldStart: number;
+      }>;
+      userModified: boolean;
+    };
+  };
+
   Glob: {
     input: {
-      path: string;
+      /**
+       * @default process.cwd()
+       */
+      path?: string;
       pattern: string;
     };
     response: {
@@ -61,18 +94,173 @@ export interface ToolSchema {
     };
   };
 
+  Grep: {
+    input: {
+      "-A"?: number;
+      "-B"?: number;
+      "-C"?: number;
+      "-i"?: boolean;
+      "-n"?: boolean;
+      glob?: string;
+      head_limit?: number;
+      multiline?: boolean;
+      /**
+       * @default "files_with_matches"
+       */
+      output_mode?: "content" | "count" | "files_with_matches";
+      path?: string;
+      pattern: string;
+      type?: string;
+    };
+    response: {
+      content: string;
+      mode: "content" | "count" | "files_with_matches";
+      numFiles: number;
+      numLines: number;
+    };
+  };
+
   LS: {
     input: {
+      ignore?: string[];
       path: string;
     };
     response: string;
   };
 
+  MultiEdit: {
+    input: {
+      edits: Array<{
+        new_string: string;
+        old_string: string;
+        /**
+         * @default false
+         */
+        replace_all?: boolean;
+      }>;
+      file_path: string;
+    };
+    response: {
+      edits: Array<{
+        new_string: string;
+        old_string: string;
+        /**
+         * @default false
+         */
+        replace_all?: boolean;
+      }>;
+      filePath: string;
+      originalFileContents: string;
+      structuredPatch: Array<{
+        lines: string[];
+        newLines: number;
+        newStart: number;
+        oldLines: number;
+        oldStart: number;
+      }>;
+      userModified: boolean;
+    };
+  };
+
+  NotebookEdit: {
+    /**
+     * @default edit_mode: "replace"
+     */
+    input:
+      | {
+          cell_id: string;
+          edit_mode: "delete";
+          new_source: string;
+          notebook_path: string;
+        }
+      | {
+          cell_id: string;
+          cell_type?: "code" | "markdown";
+          edit_mode: "replace";
+          new_source: string;
+          notebook_path: string;
+        }
+      | {
+          cell_id?: string;
+          cell_type: "code" | "markdown";
+          edit_mode: "insert";
+          new_source: string;
+          notebook_path: string;
+        };
+    response: {
+      cell_type: "code" | "markdown";
+      edit_mode: "delete" | "insert" | "replace";
+      error: string;
+      language: string;
+      new_source: string;
+    };
+  };
+
   Read: {
     input: {
       file_path: string;
+      limit?: number;
+      offset?: number;
     };
-    response: unknown;
+    response:
+      | {
+          file: {
+            cells: Array<
+              | {
+                  cell_id: string;
+                  cellType: "code";
+                  language: string;
+                  source: string;
+                }
+              | {
+                  cell_id: string;
+                  cellType: "markdown";
+                  source: string;
+                }
+            >;
+            filePath: string;
+          };
+          type: "notebook";
+        }
+      | {
+          file: {
+            content: string;
+            filePath: string;
+            numLines: number;
+            startLine: number;
+            totalLines: number;
+          };
+          type: "text";
+        };
+  };
+
+  Task: {
+    input: {
+      description: string;
+      prompt: string;
+      subagent_type: AutoComplete<
+        "general-purpose" | "output-style-setup" | "statusline-setup"
+      >;
+    };
+    response: {
+      content: Array<{
+        text: string;
+        type: "text";
+      }>;
+      totalDurationMs: number;
+      totalTokens: number;
+      totalToolUseCount: number;
+      usage: {
+        cache_creation: {
+          ephemeral_1h_input_tokens: number;
+          ephemeral_5m_input_tokens: number;
+        };
+        cache_creation_input_tokens: number;
+        cache_read_input_tokens: number;
+        input_tokens: number;
+        output_tokens: number;
+      };
+    };
   };
 
   TodoWrite: {
@@ -87,10 +275,34 @@ export interface ToolSchema {
 
   WebFetch: {
     input: {
+      /**
+       * @default 100
+       */
+      charThreshold?: number;
       prompt: string;
       url: string;
     };
-    response: unknown;
+    response: {
+      bytes: number;
+      code: number;
+      codeText: string;
+      durationMs: number;
+      result: string;
+      url: string;
+    };
+  };
+
+  Write: {
+    input: {
+      content: string;
+      file_path: string;
+    };
+    response: {
+      content: string;
+      filePath: string;
+      structuredPatch: unknown[];
+      type: "create";
+    };
   };
 }
 

--- a/src/input/types.test-d.ts
+++ b/src/input/types.test-d.ts
@@ -152,13 +152,19 @@ describe("ExtractAllHookInputsForEvent", () => {
       | HookInputs["PreToolUse"]["default"]
       // Tool-specific types of PreToolUse
       | HookInputs["PreToolUse"]["Bash"]
+      | HookInputs["PreToolUse"]["Edit"]
       | HookInputs["PreToolUse"]["Glob"]
+      | HookInputs["PreToolUse"]["Grep"]
       | HookInputs["PreToolUse"]["LS"]
-      | HookInputs["PreToolUse"]["TodoWrite"]
+      | HookInputs["PreToolUse"]["MultiEdit"]
       | HookInputs["PreToolUse"]["MyCustomTool"]
       | HookInputs["PreToolUse"]["MySecondCustomTool"]
+      | HookInputs["PreToolUse"]["NotebookEdit"]
       | HookInputs["PreToolUse"]["Read"]
+      | HookInputs["PreToolUse"]["Task"]
+      | HookInputs["PreToolUse"]["TodoWrite"]
       | HookInputs["PreToolUse"]["WebFetch"]
+      | HookInputs["PreToolUse"]["Write"]
     >();
 
     expectTypeOf<ExtractAllHookInputsForEvent<"PostToolUse">>().toEqualTypeOf<
@@ -166,13 +172,19 @@ describe("ExtractAllHookInputsForEvent", () => {
       | HookInputs["PostToolUse"]["default"]
       // Tool-specific types of PostToolUse
       | HookInputs["PostToolUse"]["Bash"]
+      | HookInputs["PostToolUse"]["Edit"]
       | HookInputs["PostToolUse"]["Glob"]
+      | HookInputs["PostToolUse"]["Grep"]
       | HookInputs["PostToolUse"]["LS"]
+      | HookInputs["PostToolUse"]["MultiEdit"]
       | HookInputs["PostToolUse"]["MyCustomTool"]
       | HookInputs["PostToolUse"]["MySecondCustomTool"]
+      | HookInputs["PostToolUse"]["NotebookEdit"]
       | HookInputs["PostToolUse"]["Read"]
+      | HookInputs["PostToolUse"]["Task"]
       | HookInputs["PostToolUse"]["TodoWrite"]
       | HookInputs["PostToolUse"]["WebFetch"]
+      | HookInputs["PostToolUse"]["Write"]
     >();
   });
 });

--- a/src/types.test-d.ts
+++ b/src/types.test-d.ts
@@ -78,13 +78,19 @@ describe("ExtractTriggeredHookInput", () => {
 
         // Tool-specific types of PostToolUse
         | HookInputs["PostToolUse"]["Bash"]
+        | HookInputs["PostToolUse"]["Edit"]
         | HookInputs["PostToolUse"]["Glob"]
+        | HookInputs["PostToolUse"]["Grep"]
         | HookInputs["PostToolUse"]["LS"]
+        | HookInputs["PostToolUse"]["MultiEdit"]
         | HookInputs["PostToolUse"]["MyCustomTool"]
         | HookInputs["PostToolUse"]["MySecondCustomTool"]
+        | HookInputs["PostToolUse"]["NotebookEdit"]
         | HookInputs["PostToolUse"]["Read"]
+        | HookInputs["PostToolUse"]["Task"]
         | HookInputs["PostToolUse"]["TodoWrite"]
         | HookInputs["PostToolUse"]["WebFetch"]
+        | HookInputs["PostToolUse"]["Write"]
 
         // PreToolUse
         | HookInputs["PreToolUse"]["MyCustomTool"]


### PR DESCRIPTION
closes #7 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added tools: Edit, MultiEdit, Grep, LS, NotebookEdit, Task, WebFetch, Write.

- Improvements
  - Bash: optional description, background run and timeout support.
  - Read: paging (limit/offset) and returns notebook or text payloads.
  - Glob: optional path with sensible default.
  - LS: ignore list support.
  - WebFetch: char-threshold and structured response.

- Tests
  - Expanded type-level tests and hook-input coverage to include the new tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->