### PR TITLE
feat: update to parity with Claude Code v2.1.119

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hooks-ts",
-  "version": "2.1.116",
+  "version": "2.1.119",
   "type": "module",
   "description": "Write claude code hooks with type safety",
   "sideEffects": false,
@@ -74,7 +74,7 @@
     "vitest": "4.1.2"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.2.116",
+    "@anthropic-ai/claude-agent-sdk": "0.2.119",
     "get-stdin": "10.0.0",
     "valibot": "^1.1.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.2.116
-        version: 0.2.116(zod@3.25.76)
+        specifier: 0.2.119
+        version: 0.2.119(zod@3.25.76)
       get-stdin:
         specifier: 10.0.0
         version: 10.0.0
@@ -104,52 +104,52 @@ packages:
   '@andrewbranch/untar.js@1.0.3':
     resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.116':
-    resolution: {integrity: sha512-mG19ovtXCpETmd5KmTU1JO2iIHZBG09IP8DmgZjLA3wLmTzpgn9Au9veRaeJeXb1EqiHiFZU+z+mNB79+w5v9g==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.119':
+    resolution: {integrity: sha512-kxnG37SZqUata2Jcp/YQ0n9Y7o/sinE/8LdG4ltM1gePh+z+0Mfa4vBUUTEBMBFth9PTovKoesIuVuyFpvO/Cw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.116':
-    resolution: {integrity: sha512-qC25N0HRM8IXbM4Qi4svH9f51Y6DciDvjLV+oNYnxkdPgDG8p/+b7vQirN7qPxytIQb2TPdoFgUeCsSe7lrQyw==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.119':
+    resolution: {integrity: sha512-9Aj8g3ELsmZuOFg17TCkikeg/Wt2ucVT8hOOPQUatzLd7BKhydrHLA0RP42nBpWECO1B/n/mPdQ4iS/LS3s2Fg==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.116':
-    resolution: {integrity: sha512-Dg/T3NkSp35ODiwdhj0KquvC6Xu+DMbyWFNkfepA3bz4oF2SVSgyOPYwVmfoJerzEUnYDldP4YhOxRrhbt0vXA==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.119':
+    resolution: {integrity: sha512-IPGWgtz+gGnD7fxKAvSf913EUT/lYBTBE8EZ7lh3+x5ZP2859LWLmrCm053Lf3nMWo/CWikZsVPwkDVwpz6tIQ==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.116':
-    resolution: {integrity: sha512-MQIcJhhPM+RPJ7kMQdOQarkJ2FlJqOiu953c08YyJOoWdHykd3DIiHws3mf1Mwl/dfFeIyshOVpNND3hyIy5Dg==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.119':
+    resolution: {integrity: sha512-v3o464XkiYehp/OKidQQirxdVb+aGSvdJvHF2zH9p33W8M/NC21zwwh4dhwDnKsyrtBIgkt2CcMwzIl30r0OtA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.116':
-    resolution: {integrity: sha512-LMYxUMa1nK4N9BPRJdcGBAvl9rjTI4ZHo+kfAKrJ3MlfB6VFF1tRIubwsWOaOtkuNazMdAYovsZJg4bdzOBBTQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.119':
+    resolution: {integrity: sha512-QYxFNAe4FFridPkKhGlNcNBJ0TaIygWYyvfI9g4kX0i+RVbresUWuZVkWY06ioJ0fXoixFJ+HNQBMB7dLrIp8Q==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.116':
-    resolution: {integrity: sha512-Bww1fzQB+vcF0tRhmCAlwSsN4wR2HgX7pBT9AWuwzJj6DKsVC23N54Ea80lsnM7dTUtUTrGYMTwVUHTWqfYnfQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.119':
+    resolution: {integrity: sha512-9ePt4ZN+hsqDw4AgS4KtcWIGKfL9Oq28kwkrTER/QAcSrVKxiLonp81cCLzg7Ok/IUJu4Cfd71GZbFv/WE54zw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.116':
-    resolution: {integrity: sha512-h0YO1vkTIeUtffQhONrYbNC1pXmk1yjb1xxMEw7bAwucqtFoFpLDWe+q4+RhxaQr8ZOj6LtRE/U3dzPWHOlshA==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.119':
+    resolution: {integrity: sha512-p/TjcKQvkCYtXGPlR+mdyNwqCmvRcQL34Wtq0yUZ+iqmI/eyCe59IJ3AZrE0EZoqmiAevEYzatPIt9sncC9uxw==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.116':
-    resolution: {integrity: sha512-3lllmtDFHgpW0ZM3iNvxsEjblrgRzF9Qm1lxTOtunP3hIn+pA/IkWMtKlN1ixxWiaBguLVQkJ90V6JHsvJJIvw==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.119':
+    resolution: {integrity: sha512-k98Ju0wtktm6FhqTE/cXlVr6K4kGqBolVjEGzeKkW6ZILc7124euwNapAvkQCwMAavAxS/ZnO3jdKMtHtwTVTA==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.2.116':
-    resolution: {integrity: sha512-5NKpgaOZkzNCGCvLxJZUVGimf5IcYmpQ2x2XrR9ilK+2UkWrnnwcUfIWo8bBz9e7lSYcUf9XleGigq2eOOF7aw==}
+  '@anthropic-ai/claude-agent-sdk@0.2.119':
+    resolution: {integrity: sha512-6AvthpsaOTlkn514brSGOcCSLHDXODnU+ExN1O3CJCjxr5RBcmzR057C9EIM0G7IchnXsRfMZgRO1QKsjTXdbA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
@@ -4073,44 +4073,44 @@ snapshots:
 
   '@andrewbranch/untar.js@1.0.3': {}
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.116':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.119':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.116':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.119':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.116':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.119':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.116':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.119':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.116':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.119':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.116':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.119':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.116':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.119':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.116':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.119':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.2.116(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.2.119(zod@3.25.76)':
     dependencies:
       '@anthropic-ai/sdk': 0.81.0(zod@3.25.76)
       '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
       zod: 3.25.76
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.116
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.116
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.116
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.116
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.116
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.116
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.116
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.116
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.119
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.119
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.119
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.119
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.119
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.119
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.119
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.119
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color

--- a/src/hooks/event.ts
+++ b/src/hooks/event.ts
@@ -7,6 +7,7 @@ export type SupportedHookEvent =
   | "PreToolUse"
   | "PostToolUse"
   | "PostToolUseFailure"
+  | "PostToolBatch"
   | "Notification"
   | "UserPromptSubmit"
   | "UserPromptExpansion"

--- a/src/hooks/input/schemas.ts
+++ b/src/hooks/input/schemas.ts
@@ -86,7 +86,11 @@ export const HookInputSchemas = {
     tool_calls: v.array(
       v.object({
         tool_input: v.unknown(),
-        tool_name: v.string(),
+        tool_name: v.pipe(
+          // parse as string, then type as AutoComplete<string>
+          v.string(),
+          v.guard((s): s is AutoComplete<string> => true),
+        ),
         tool_response: v.exactOptional(v.unknown()),
         tool_use_id: v.string(),
       }),

--- a/src/hooks/input/schemas.ts
+++ b/src/hooks/input/schemas.ts
@@ -62,6 +62,7 @@ export const HookInputSchemas = {
       v.guard((s): s is AutoComplete<string> => true),
     ),
 
+    duration_ms: v.exactOptional(v.number()),
     tool_input: v.unknown(),
     tool_response: v.unknown(),
     tool_use_id: v.string(),
@@ -74,10 +75,22 @@ export const HookInputSchemas = {
       v.guard((s): s is AutoComplete<string> => true),
     ),
 
+    duration_ms: v.exactOptional(v.number()),
     error: v.string(),
     is_interrupt: v.exactOptional(v.boolean()),
     tool_input: v.unknown(),
     tool_use_id: v.string(),
+  }),
+
+  PostToolBatch: buildHookInputSchema("PostToolBatch", {
+    tool_calls: v.array(
+      v.object({
+        tool_input: v.unknown(),
+        tool_name: v.string(),
+        tool_response: v.exactOptional(v.unknown()),
+        tool_use_id: v.string(),
+      }),
+    ),
   }),
 
   Notification: buildHookInputSchema("Notification", {

--- a/src/hooks/input/types.test-d.ts
+++ b/src/hooks/input/types.test-d.ts
@@ -173,6 +173,25 @@ describe("HookInputs", () => {
       }>();
     });
   });
+
+  describe("PostToolBatch", () => {
+    type ToolCallItem = HookInput["PostToolBatch"]["default"]["tool_calls"][number];
+    type MySecondCustomToolCall = Extract<ToolCallItem, { tool_name: "MySecondCustomTool" }>;
+
+    it("should narrow tool_name and tool_input by tool_name discriminant", () => {
+      expectTypeOf<MySecondCustomToolCall>().toMatchObjectType<{
+        tool_input: { param: string };
+        tool_name: "MySecondCustomTool";
+        tool_use_id: string;
+      }>();
+    });
+
+    it("should infer optional tool_response by tool_name", () => {
+      expectTypeOf<MySecondCustomToolCall["tool_response"]>().toEqualTypeOf<
+        { success: boolean } | undefined
+      >();
+    });
+  });
 });
 
 describe("Auto Completion Ability", () => {

--- a/src/hooks/input/types.test-d.ts
+++ b/src/hooks/input/types.test-d.ts
@@ -62,6 +62,7 @@ describe("HookInputs", () => {
         agent_id?: string;
         agent_type?: string;
         cwd: string;
+        duration_ms?: number;
         hook_event_name: "PostToolUse";
         permission_mode?: string;
         session_id: string;
@@ -94,6 +95,7 @@ describe("HookInputs", () => {
         agent_id?: string;
         agent_type?: string;
         cwd: string;
+        duration_ms?: number;
         error: string;
         hook_event_name: "PostToolUseFailure";
         is_interrupt?: boolean;

--- a/src/hooks/input/types.ts
+++ b/src/hooks/input/types.ts
@@ -36,9 +36,13 @@ export type HookInput = {
             ? ToolSpecificPermissionDeniedInput & {
                 default: BaseHookInputs["PermissionDenied"];
               }
-            : {
-                default: BaseHookInputs[EventKey];
-              };
+            : EventKey extends "PostToolBatch"
+              ? {
+                  default: PostToolBatchInput;
+                }
+              : {
+                  default: BaseHookInputs[EventKey];
+                };
 };
 
 /**
@@ -139,4 +143,17 @@ type ToolSpecificPermissionDeniedInput = {
     tool_input: ToolSchema[K]["input"];
     tool_name: K;
   };
+};
+
+type BatchedToolCall = {
+  [K in keyof ToolSchema]: {
+    tool_input: ToolSchema[K]["input"];
+    tool_name: K;
+    tool_response?: ToolSchema[K]["response"];
+    tool_use_id: string;
+  };
+}[keyof ToolSchema];
+
+type PostToolBatchInput = Omit<BaseHookInputs["PostToolBatch"], "tool_calls"> & {
+  tool_calls: BatchedToolCall[];
 };

--- a/src/hooks/output/index.ts
+++ b/src/hooks/output/index.ts
@@ -12,6 +12,8 @@ export type HookOutput = {
 
   PostToolUseFailure: PostToolUseFailureHookOutput;
 
+  PostToolBatch: PostToolBatchHookOutput;
+
   UserPromptExpansion: UserPromptExpansionHookOutput;
   UserPromptSubmit: UserPromptSubmitHookOutput;
 
@@ -186,6 +188,17 @@ interface PostToolUseHookOutput extends CommonHookOutputs {
 interface PostToolUseFailureHookOutput extends CommonHookOutputs {
   hookSpecificOutput?: {
     hookEventName: "PostToolUseFailure";
+
+    /**
+     * Adds context for Claude to consider.
+     */
+    additionalContext?: string;
+  };
+}
+
+interface PostToolBatchHookOutput extends CommonHookOutputs {
+  hookSpecificOutput?: {
+    hookEventName: "PostToolBatch";
 
     /**
      * Adds context for Claude to consider.

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,6 @@ import type {
   AskUserQuestionOutput,
   BashInput,
   BashOutput,
-  ConfigInput,
-  ConfigOutput,
   EnterWorktreeInput,
   EnterWorktreeOutput,
   ExitPlanModeInput,
@@ -85,11 +83,6 @@ export interface ToolSchema {
   Bash: {
     input: BashInput;
     response: BashOutput;
-  };
-
-  Config: {
-    input: ConfigInput;
-    response: ConfigOutput;
   };
 
   Edit: {


### PR DESCRIPTION
## Changes

### Upstream parity (Claude Code v2.1.119)

- Add `PostToolBatch` hook event with `tool_calls` input schema and `additionalContext` output
- Add `duration_ms` optional field to `PostToolUse` and `PostToolUseFailure` hook inputs
- Remove `Config` tool (`ConfigInput`/`ConfigOutput` removed from upstream SDK)

### Type improvement for `PostToolBatch`

`tool_calls` items are now typed as a `ToolSchema`-based discriminated union, consistent with `PostToolUse` and `PreToolUse`. TypeScript narrows `tool_input` and `tool_response` when branching on `tool_name`:

```ts
for (const call of input.tool_calls) {
  if (call.tool_name === "Bash") {
    call.tool_input   // BashInput
    call.tool_response // BashOutput | undefined
  }
}
```

Custom tools added via `ToolSchema` declaration merging are automatically included in the union.